### PR TITLE
Use a C89 function declaration for main.

### DIFF
--- a/rblcheck.c
+++ b/rblcheck.c
@@ -328,9 +328,7 @@ int full_rblcheck( char * addr )
 
 /*-- MAINLINE ---------------------------------------------------------------*/
 
-int main( argc, argv )
-	int argc;
-	char **argv;
+int main( int argc, char ** argv )
 {
 	int a;
 	struct rbl * ptr;


### PR DESCRIPTION
This fixes a -Wdeprecated-non-prototypes warning from clang from LLVM15.